### PR TITLE
Allow installation by non-root

### DIFF
--- a/do_install
+++ b/do_install
@@ -15,7 +15,7 @@ echo "Installing from $tmp_man to $mandir/man3"
 mkdir -p $mandir/man3
 for file in "$tmp_man"/*.3 ; do
   out=$mandir/man3/$(basename "$file");
-  install -g 0 -o 0 -m 0644 "$file" "$out";
+  install -m 0644 "$file" "$out";
   gzip -f "$out";
 done
 echo "Done"


### PR DESCRIPTION
Attempting to force root ownership for the man pages doesn't help users with
root access, it just makes it impossible for non-root users to install it.

Use cases:
- Non-admin installing to home directory

```
      $ export MANPATH=$MANPATH:$HOME/share/man
      $ ./configure --prefix=$HOME
      $ make install
```
- Packager using DESTDIR

```
      $ ./configure
      $ make install DESTDIR=/tmp/stdman
      $ tar czf stdman.tar.gz /tmp/stdman/* # Or a real packaging tool...
```
