### PR TITLE
Add FreeBSD support

### DIFF
--- a/configure
+++ b/configure
@@ -23,6 +23,7 @@ set -o nounset
 UNAME_LINUX=0
 UNAME_CYGWIN=0
 UNAME_OSX=0
+UNAME_FREEBSD=0
 UNAME=$(uname)
 if [ "$UNAME" = "Linux" ];
 then
@@ -33,6 +34,9 @@ then
 elif [ "$(uname -o)" = "Cygwin" ];
 then
   UNAME_CYGWIN=1
+elif [ "$UNAME" = "FreeBSD" ];
+then
+  UNAME_FREEBSD=1
 else
   echo "Invalid uname ($UNAME): Unsuppported platform" 1>&2
   exit 1
@@ -64,6 +68,11 @@ then
 elif [ "1" -eq "$UNAME_CYGWIN" ];
 then
   log "Platform: Cygwin (NOT TESTED)"
+elif [ "1" -eq "$UNAME_FREEBSD" ];
+then
+  log "Platform: FreeBSD"
+  CXX_PLATFORM_FLAGS="-I/usr/local/include"
+  LD_PLATFORM_LIBS="-L/usr/local/lib"
 fi
 
 # Parse params

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright © 2014 Jesse 'Jeaye' Wilkerson
 # See licensing in LICENSE file, or at:

--- a/do_generate
+++ b/do_generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright © 2014 Jesse 'Jeaye' Wilkerson
 # See licensing in LICENSE file, or at:

--- a/do_install
+++ b/do_install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright © 2014 Jesse 'Jeaye' Wilkerson
 # See licensing in LICENSE file, or at:

--- a/do_link
+++ b/do_link
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright © 2014 Jesse 'Jeaye' Wilkerson
 # See licensing in LICENSE file, or at:


### PR DESCRIPTION
This pull request changes all of the shebangs to /usr/bin/env bash, as bash is installed to /usr/local/bin on FreeBSD. Additionally it adds support for building on FreeBSD by adding another OS entry in the configure file.