### PR TITLE
configure: remove unnecessary code

### DIFF
--- a/configure
+++ b/configure
@@ -43,8 +43,6 @@ else
 fi
 
 log() { echo "$@" 1>&2; }
-log_start() { printf "$@" 1>&2; }
-log_end() { echo "$@" 1>&2; }
 
 PROJECT=stdman
 log "Configuring ${PROJECT}"


### PR DESCRIPTION
 * remove the 'rm -f Makefile' line:  the sed line that follows that
   line truncates the file if it exists and creates it if it doesn't.
   there is no need to remove the file prior.

 * remove functions log_start() and log_end():  these functions are not
   used.