### PR TITLE
Use shell expansion instead of basename in install

### DIFF
--- a/do_install
+++ b/do_install
@@ -14,7 +14,7 @@ set -o nounset
 echo "Installing from $tmp_man to $mandir/man3"
 mkdir -p $mandir/man3
 for file in "$tmp_man"/*.3 ; do
-  out=$mandir/man3/$(basename "$file");
+  out=$mandir/man3/${file##*/};
   install -m 0644 "$file" "$out";
   gzip -f "$out";
 done


### PR DESCRIPTION
This makes it about twice as fast.