### PR TITLE
Preserve timestamps on installation

### DIFF
--- a/do_install
+++ b/do_install
@@ -15,7 +15,7 @@ echo "Installing from $tmp_man to $mandir/man3"
 mkdir -p $mandir/man3
 for file in "$tmp_man"/*.3 ; do
   out=$mandir/man3/$(basename "$file");
-  install -m 0644 "$file" "$out";
+  install -p -m 0644 "$file" "$out";
   gzip -f "$out";
 done
 echo "Done; it's advised to run 'sudo mandb' (GNU) or 'sudo makewhatis' (BSD) now."


### PR DESCRIPTION
Passing `-p` to `install` will preserve the timestamps from the original
files. This helps ensure that builds from the same source are
reproducible [1].

Tested with both BSD and GNU `install` [2, 3], so this will work on both
macOS and Linux.

[1] See https://reproducible-builds.org.
[2] https://man7.org/linux/man-pages/man1/install.1.html
[3] https://www.freebsd.org/cgi/man.cgi?query=install
